### PR TITLE
Enable BRAT compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,11 @@ Run `npm install` once to install dependencies. After making changes, compile th
 npm run build
 ```
 
-The compiled files will appear in the `dist/` directory.
+The compiled files will appear in the `dist/` directory and `main.js` will also
+be copied to the repository root.
+
+## Installing via BRAT
+
+This repository is compatible with the [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin.
+Add the GitHub URL of this repo to BRAT's beta plugins list to install and receive updates.
 

--- a/main.js
+++ b/main.js
@@ -1,0 +1,10 @@
+import { Plugin, Notice } from 'obsidian';
+export default class HelloNoticePlugin extends Plugin {
+    async onload() {
+        this.addCommand({
+            id: 'show-hello-notice',
+            name: 'Show Hello Notice',
+            callback: () => new Notice('Hello!'),
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "description": "Obsidian plugin that shows a Hello notice.",
   "scripts": {
-    "build": "tsc -p ."
+    "build": "tsc -p . && cp dist/main.js main.js",
+    "dev": "tsc -watch -p . && cp dist/main.js main.js"
   },
   "devDependencies": {
     "obsidian": "^1.5.11",


### PR DESCRIPTION
## Summary
- generate `main.js` at repository root
- add build script to copy compiled output to root
- document BRAT usage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68569fc9dffc832e82d616066e449f38