### PR TITLE
Fix workflow commit issue for dist main.js

### DIFF
--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   bump:
     if: github.actor != 'github-actions[bot]'

--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,8 @@ out
 
 # Nuxt.js build / generate output
 .nuxt
-dist
+dist/*
+!dist/main.js
 
 # Gatsby files
 .cache/


### PR DESCRIPTION
## Summary
- make `dist/main.js` not ignored
- allow workflow push by granting write permission

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856af2f56a8832e8721ce52fa6e8234