### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,11 @@ name: Release Obsidian plugin
 
 on:
   push:
-    branches: [main]
+    tags:
+      - '*'
+
+permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- trigger release workflow on tag push
- grant `contents: write` permission so `gh` can create releases

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856b31eeefc832e8c58002fed872588