### PR TITLE
Enable release tagging

### DIFF
--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -42,3 +42,9 @@ jobs:
         with:
           add: 'manifest.json main.js dist/main.js'
           message: 'chore: bump manifest version'
+
+      - name: Create tag for release
+        run: |
+          version=$(node -p "require('./manifest.json').version")
+          git tag "v$version"
+          git push origin "v$version"


### PR DESCRIPTION
## Summary
- tag release in `update-manifest.yml` so `release.yml` runs

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856b73c69d0832ebfe00809710cc9a7