### PR TITLE
Add manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,64 @@
+name: Manual Plugin Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Optional tag name for the release. Defaults to manifest version.'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Determine tag name
+        id: tag
+        run: |
+          input="${{ github.event.inputs.tag }}"
+          if [ -z "$input" ]; then
+            version=$(node -p "require('./manifest.json').version")
+            tag="v$version"
+          else
+            tag="$input"
+          fi
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
+      - name: Create Git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.tag.outputs.tag }}
+          git push origin ${{ steps.tag.outputs.tag }}
+
+      - name: Create plugin zip
+        run: |
+          mkdir -p release
+          cp dist/main.js manifest.json release/
+          cd release
+          zip plugin.zip main.js manifest.json
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: Release ${{ steps.tag.outputs.tag }}
+          body: |
+            ✅ Manual release triggered by ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a workflow for manual plugin release

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d5cc430c832e9dc56a1a2c43e0cc