### PR TITLE
Add release asset to manual workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -60,5 +60,6 @@ jobs:
           name: Release ${{ steps.tag.outputs.tag }}
           body: |
             ✅ Manual release triggered by ${{ github.actor }}
+          files: release/plugin.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- upload plugin.zip asset in the manual release workflow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856f0701180832e804c1cdec4859be6