### PR TITLE
Add RDF file structure info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,42 @@
-# Exo Hello Notice Plugin
+# Exocortex Hello Notice Plugin
 
-This is a minimal Obsidian community plugin that adds a command to display a `Notice` with the text `Hello!`.
+This plugin adds a simple command that displays a "Hello World!" notice inside Obsidian.
+It also demonstrates the file layout used for RDF-friendly knowledge bases.
+
+## Features
+- Command **Show Hello Notice** pops up an Obsidian `Notice` with the text "Hello World!".
+
+## RDF-friendly vault structure
+
+The repository is organized so each Markdown file represents a small RDF subgraph in frontmatter.
+The file name is the subject, each frontmatter key is a predicate, and the value is its object.
+Because YAML frontmatter does not allow colons in keys, the prefix separator `:` is written as `__` in file names and property names.
+
+### Ontology folders
+
+All TBox ontologies live under `02 Ontology`:
+
+- `0 Meta` – basic ontologies `owl`, `rdf` and `rdfs`.
+- `1 Exo/exo` – the exocortex meta-ontology `http://exocortex.my/ontology/exo` containing decorator classes over `owl:Class`, `rdf:Resource` and others.
+- `2 Custom` – domain ontologies depending on `exo` but not on external vocabularies. Examples include:
+  - `ims` (Information Management System) with classes like `Concept`, `Context`, `Term`, `Definition`, `Quote`, `Person`.
+  - `ems` (Effort Management System) with classes like `Effort`, `EffortStatus`, `Meeting`, `Project`, `Task`.
+  Each ontology resides in its own folder and provides a file `!namespace-name.md` describing the namespace along with files for individual classes such as `ems__Effort.md`.
+
+### Knowledge folders
+
+All ABox data is stored in `03 Knowledge`. By default a single ontology `kitelev_personal` is used in this vault.
 
 ## Building
 
-Run `npm install` once to install dependencies. After making changes, compile the plugin with:
+Run `npm install` once to install dependencies. Then compile the plugin with:
 
 ```bash
 npm run build
 ```
 
-The compiled files will appear in the `dist/` directory and `main.js` will also
-be copied to the repository root.
+The compiled files will appear in the `dist/` directory and `main.js` will be copied to the repository root.
 
 ## Installing via BRAT
 
-This repository is compatible with the [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin.
-Add the GitHub URL of this repo to BRAT's beta plugins list to install and receive updates.
-
+This repository can be added to the [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin's beta list to install and receive updates.

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ class HelloNoticePlugin extends obsidian_1.Plugin {
         this.addCommand({
             id: 'show-hello-notice',
             name: 'Show Hello Notice',
-            callback: () => new obsidian_1.Notice('Hello!'),
+            callback: () => new obsidian_1.Notice('Hello World!'),
         });
     }
 }


### PR DESCRIPTION
## Summary
- document Ontology and Knowledge folder structure in README
- rebuild plugin to update compiled `main.js`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68583c8738cc832eab1b616c068555a7